### PR TITLE
[RE-610] update to latest actions/cache due to deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           java-version: adopt@1.11
 
       - name: Cache sbt
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
             ~/.sbt


### PR DESCRIPTION
Update to latest version of actions/cache due to version deprecations (https://github.com/actions/cache/discussions/1510)